### PR TITLE
Fix typo misspell in navigation

### DIFF
--- a/navigation.html
+++ b/navigation.html
@@ -20,7 +20,7 @@
 <!--          <li><a href="/docs/core/snaps">The kinds of snaps</a></li>-->
           <li><a href="/docs/core/interfaces">Interfaces (plugs and slots)</a></li>
           <li><a href="/docs/core/updates">Transactional updates</a></li>
-          <li><a href="/docs/core/versions">Mutiple snaps versions &amp; garbage collection</a></li>
+          <li><a href="/docs/core/versions">Multiple snaps versions &amp; garbage collection</a></li>
       </ul>
     </li>
     <li>


### PR DESCRIPTION
'Mutiple' should be 'Multiple'

Fixes: https://github.com/ubuntudesign/snapcraft.io/issues/209