### PR TITLE
Fix typo -  “philosophy”, not “phisophy”

### DIFF
--- a/snaps/index.md
+++ b/snaps/index.md
@@ -6,6 +6,6 @@ title: "Snaps"
 This section provides you with details about the content and structure of a snap. There is sufficient information in this section to enable you to create your own snap files manually. That said, this information is primarily meant as background to help with your understanding of how Snapcraft builds snaps.
 
 - [What is a snap?](/docs/snaps/intro)
-- [Snapping phisophy](/docs/snaps/philosophy)
+- [Snapping philosophy](/docs/snaps/philosophy)
 - [the folder structure of content in a snap](/docs/snaps/structure)
 - [the content of a snap's metadata YAML file](/docs/snaps/metadata)


### PR DESCRIPTION
Fix spelling typo in docs: “philosophy”, not “phisophy”

Fixes: https://github.com/ubuntudesign/snapcraft.io/issues/234