### PR TITLE
Patch with minor typos

### DIFF
--- a/core/install.md
+++ b/core/install.md
@@ -42,7 +42,7 @@ Install the [gentoo-snappy overlay](https://github.com/zyga/gentoo-snappy).
 
 Install the [snap meta layer](https://github.com/morphis/meta-snappy/blob/master/README.md).
 
-### OpenSuse
+### openSUSE
 
 ```
 sudo zypper addrepo http://download.opensuse.org/repositories/system:/snappy/openSUSE_Leap_42.2/ snappy

--- a/core/snapd.md
+++ b/core/snapd.md
@@ -26,7 +26,7 @@ The snapd system aims to fix these challenges by offering:
 On a snapd system these features are implemented by:
 
 - **snapd**, a management environment that handles installing and updating snaps using the transactional system, as well as [garbage collection](/docs/core/versions) of old versions of snaps.
-- **snapd-confine**, an execution environment for the applications and services delivered in snap packages.
+- **snap-confine**, an execution environment for the applications and services delivered in snap packages.
 
 ![Snaps are self contained, confined applications that can make use of features in other snaps using Interfaces.](../media/snap_in_snappy_system.png "Snaps in the Snapd System")
 

--- a/core/snapd.md
+++ b/core/snapd.md
@@ -19,8 +19,8 @@ The snapd system aims to fix these challenges by offering:
 
   - Offers snaps a secure storage area isolated from other snaps.
   - Enables snaps to make features available to other snaps and for other snaps to consume those features over defined interfaces.
-  - A store where developers can easily make their software directly available to users and from which devices can automatically pull updates on a daily basis.
 
+- A store where developers can easily make their software directly available to users and from which devices can automatically pull updates on a daily basis.
 - A simple transactional update system where snaps can be easily uninstalled (by deleting the snap package) or rolled back (by reverting to the previous snap image and private storage area).
 
 On a snapd system these features are implemented by:

--- a/core/updates.md
+++ b/core/updates.md
@@ -2,7 +2,7 @@
 title: "Transactional updates"
 ---
 
-Snapd systems employ a method of transactional update that is available for all snaps: application, gadget, OS, and kernel.
+Snapd systems employ a method of transactional updates that is available for all snaps: application, gadget, OS, and kernel.
 
 
 ## Installation


### PR DESCRIPTION
This patch resolves these four minor typos:

* Replaces an `OpenSuse` mention with `openSUSE` which is the preferred way due to its branding (also makes it consistent with the URL of the repo in the command in next line)
* Replaces a sub-bulletpoint with a bulletpoint
* Fixes a typo in the `snap-confine` name
* Fixes a word by replacing it with its plural