### PR TITLE
deprecation-notices: add dn4 for 'history' rename

### DIFF
--- a/deprecation-notices/dn4.md
+++ b/deprecation-notices/dn4.md
@@ -6,6 +6,7 @@ title: DN4
 
 _introduced in snapcraft 2.28_
 
-The `history` command is now called `list-revisions` with an alias of `revisions`
+The `history` command is now called `list-revisions` with an alias of `revisions`.
+
 The `history` command has been deprecated and will be removed in a future version
 of snapcraft.

--- a/deprecation-notices/dn4.md
+++ b/deprecation-notices/dn4.md
@@ -1,0 +1,11 @@
+---
+title: DN4
+---
+
+**The `history` command has been renamed to `list-revisions`**
+
+_introduced in snapcraft 2.28_
+
+The `history` command is now called `list-revisions` with an alias of `revisions`
+The `history` command has been deprecated and will be removed in a future version
+of snapcraft.


### PR DESCRIPTION
'history' is now 'list-revisions' and the alias 'revisions'