### PR TITLE
Extend snapd installation instructions

### DIFF
--- a/core/install-arch-linux.md
+++ b/core/install-arch-linux.md
@@ -1,0 +1,24 @@
+---
+title: Install snapd on Arch Linux
+---
+
+snapd is available in the community repository of Arch Linux. It can
+be installed via:
+
+```
+$ sudo pacman -S snapd
+```
+
+Once installed the systemd unit which is responsible to manage the
+main communication socket for snapd is not automatically enabled and
+you have to do this manually:
+
+```
+$ sudo systemctl enable --now snapd.socket
+```
+
+Afterwards everything is setup to get you started with snaps.
+
+## Next Steps
+
+ * [Using snaps](usage.md)

--- a/core/install-arch-linux.md
+++ b/core/install-arch-linux.md
@@ -21,4 +21,4 @@ Afterwards everything is setup to get you started with snaps.
 
 ## Next Steps
 
- * [Using snaps](usage.md)
+ * [Using snaps](usage)

--- a/core/install-debian.md
+++ b/core/install-debian.md
@@ -16,4 +16,4 @@ Afterwards everything is setup to get you started with snaps.
 
 ## Next Steps
 
- * [Using snaps](usage.md)
+ * [Using snaps](usage)

--- a/core/install-debian.md
+++ b/core/install-debian.md
@@ -1,0 +1,19 @@
+---
+title: Install snapd on Debian
+---
+
+On Debian snapd is available as part of the testing and unstable
+versions. It is currently not available in any stable version but
+will be soon
+
+Generally you can install snapd on a Debian distribution via:
+
+```
+$ sudo apt install snapd
+```
+
+Afterwards everything is setup to get you started with snaps.
+
+## Next Steps
+
+ * [Using snaps](usage.md)

--- a/core/install-fedora.md
+++ b/core/install-fedora.md
@@ -33,4 +33,4 @@ Afterwards everything is setup to get you started with snaps.
 
 ## Next Steps
 
- * [Using snaps](usage.md)
+ * [Using snaps](usage)

--- a/core/install-fedora.md
+++ b/core/install-fedora.md
@@ -1,0 +1,36 @@
+---
+title: Install snapd on Fedora
+---
+
+snapd packages for Fedora are currently not available as part of
+the official distribution but are maintained in a community
+repository in [copr](https://copr.fedorainfracloud.org/). In the
+near future snapd will be available in the official Fedora
+distribution repositories.
+
+To install snapd from the community repository you have to enable
+it first:
+
+```
+$ sudo dnf copr enable zyga/snapcore
+```
+
+Now you can install the snapd package with:
+
+```
+$ sudo dnf install snapd
+```
+
+Once the snapd package is successfully installed you have to
+enable the systemd unit which takes care about snapd's main
+communication socket as this is not yet automatically done:
+
+```
+$ sudo systemctl enable --now snapd.socket
+```
+
+Afterwards everything is setup to get you started with snaps.
+
+## Next Steps
+
+ * [Using snaps](usage.md)

--- a/core/install-gentoo.md
+++ b/core/install-gentoo.md
@@ -7,4 +7,4 @@ further instructions are available as part of the repository [here](https://gith
 
 ## Next Steps
 
- * [Using snaps](usage.md)
+ * [Using snaps](usage)

--- a/core/install-gentoo.md
+++ b/core/install-gentoo.md
@@ -1,0 +1,10 @@
+---
+title: Install snapd on Gentoo
+---
+
+snapd for Gentoo is currently available from a community repository. All
+further instructions are available as part of the repository [here](https://github.com/zyga/gentoo-snappy).
+
+## Next Steps
+
+ * [Using snaps](usage.md)

--- a/core/install-oe-yocto.md
+++ b/core/install-oe-yocto.md
@@ -1,0 +1,82 @@
+---
+title: Install snapd on OpenEmbedded / Yocto
+---
+
+As OpenEmbedded / Yocto is a meta distribution build system which doesn't provide
+you by default with any binary packages we don't do this either for snapd.
+
+To allow inclusion of snapd in any Linux distribution build with OpenEmbedded /
+Yocto a so called meta-layer [meta-snappy](https://github.com/morphis/meta-snappy/)
+exists which include all necessary recipes. These recipes cover necessary
+components and define dependencies on other dependencies outside of the
+meta-snappy layer.
+
+To keep things simple we only show here how you can include meta-snappy in a
+generic Yocto build targetting the QEMU emulator. More information about how
+to start with Yocto can be found [here](https://www.yoctoproject.org/docs/2.2/yocto-project-qs/yocto-project-qs.html).
+
+First setup the Yocto build environment based on the 2.2 (morty) release:
+
+```
+$ git clone -b morty git://git.yoctoproject.org/poky
+```
+
+Now we need to add the meta-snappy layer into the build environment:
+
+```
+$ cd poky
+$ git clone https://github.com/morphis/meta-snappy.git
+```
+
+After this we can start to setup the actual build environment:
+
+```
+$ source oe-init-build-env
+```
+
+Once that is done we need to add the meta-snappy layer in the just created
+*conf/bblayers.conf* configuration file. Adjust the file to look like this
+but replace */path/to* with the correct absolute path to the meta-snappy repository
+we clone above:
+
+```
+[...]
+BBLAYERS ?= " \
+   ...
+   /path/to/meta-snappy \
+"
+```
+
+The last thing we need to do now before we can start a build is to adjust our
+conf/local.conf configuration file to enable a few features snapd depends on:
+
+```
+$ cat << EOF >> conf/local.conf
+DISTRO_FEATURES_append = " systemd"
+VIRTUAL-RUNTIME_init_manager = "systemd"
+DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
+VIRTUAL-RUNTIME_initscripts = ""
+EOF
+```
+
+That's it. Now we can start the build of the demo image the meta-snappy layer
+provides which will setup up everything correctly:
+
+```
+$ bitbake snapd-demo-image
+```
+
+The build will take, depending on your machine, a while as its build a whole
+distribution from scratch. Once the build is done you can load the created image
+in QEMU with:
+
+```
+$ runqemu qemux86
+```
+
+For more information about Yocto / OpenEmbedded please have a look at the official
+documentation [here](https://www.yoctoproject.org/documentation).
+
+## Next Steps
+
+ * [Using snaps](usage.md)

--- a/core/install-oe-yocto.md
+++ b/core/install-oe-yocto.md
@@ -1,13 +1,12 @@
 ---
-title: Install snapd on OpenEmbedded / Yocto
+title: Install snapd on OpenEmbedded/Yocto
 ---
 
-As OpenEmbedded / Yocto is a meta distribution build system which doesn't provide
-you by default with any binary packages we don't do this either for snapd.
+As OpenEmbedded/Yocto is a meta distribution build system which doesn't provide
+you by default with any binary packages, we don't do this either for snapd.
 
-To allow inclusion of snapd in any Linux distribution build with OpenEmbedded /
-Yocto a so called meta-layer [meta-snappy](https://github.com/morphis/meta-snappy/)
-exists which include all necessary recipes. These recipes cover necessary
+To allow inclusion of snapd in any Linux distribution built with OpenEmbedded/Yocto, a so called meta-layer [meta-snappy](https://github.com/morphis/meta-snappy/)
+exists which include all necessary recipes. These recipes cover required
 components and define dependencies on other dependencies outside of the
 meta-snappy layer.
 
@@ -15,7 +14,7 @@ To keep things simple we only show here how you can include meta-snappy in a
 generic Yocto build targetting the QEMU emulator. More information about how
 to start with Yocto can be found [here](https://www.yoctoproject.org/docs/2.2/yocto-project-qs/yocto-project-qs.html).
 
-First setup the Yocto build environment based on the 2.2 (morty) release:
+First, setup the Yocto build environment based on the 2.2 (morty) release:
 
 ```
 $ git clone -b morty git://git.yoctoproject.org/poky
@@ -28,16 +27,15 @@ $ cd poky
 $ git clone https://github.com/morphis/meta-snappy.git
 ```
 
-After this we can start to setup the actual build environment:
+After this we can start setting up the actual build environment:
 
 ```
 $ source oe-init-build-env
 ```
 
-Once that is done we need to add the meta-snappy layer in the just created
-*conf/bblayers.conf* configuration file. Adjust the file to look like this
-but replace */path/to* with the correct absolute path to the meta-snappy repository
-we clone above:
+Once that is done, we need to add the meta-snappy layer in the just created
+`conf/bblayers.conf` configuration file. Adjust the file to look like the follwoing, but replace `/path/to` with the correct absolute path to the meta-snappy repository
+we just cloned:
 
 ```
 [...]
@@ -48,7 +46,7 @@ BBLAYERS ?= " \
 ```
 
 The last thing we need to do now before we can start a build is to adjust our
-conf/local.conf configuration file to enable a few features snapd depends on:
+`conf/local.conf` configuration file to enable a few features snapd depends on:
 
 ```
 $ cat << EOF >> conf/local.conf
@@ -60,13 +58,13 @@ EOF
 ```
 
 That's it. Now we can start the build of the demo image the meta-snappy layer
-provides which will setup up everything correctly:
+provides, which will setup everything correctly:
 
 ```
 $ bitbake snapd-demo-image
 ```
 
-The build will take, depending on your machine, a while as its build a whole
+The build can take a while, depending on your machine, as it's building a whole
 distribution from scratch. Once the build is done you can load the created image
 in QEMU with:
 
@@ -74,9 +72,9 @@ in QEMU with:
 $ runqemu qemux86
 ```
 
-For more information about Yocto / OpenEmbedded please have a look at the official
+For more information about OpenEmbedded/Yocto please have a look at the official
 documentation [here](https://www.yoctoproject.org/documentation).
 
 ## Next Steps
 
- * [Using snaps](usage.md)
+ * [Using snaps](usage)

--- a/core/install-opensuse.md
+++ b/core/install-opensuse.md
@@ -1,0 +1,41 @@
+---
+title: Install snapd on openSUSE
+---
+
+For openSUSE snapd is not yet included in the official distribution but can be
+installed from a community repository which is available [here](https://build.opensuse.org/package/show/system:snappy/snapd).
+
+The repository currently supports the 42.2 release and Tumbleweed. The Installation
+process for both is similar. First we need to add the repository itself.
+
+For 42.2:
+
+
+```
+$ sudo zypper addrepo http://download.opensuse.org/repositories/system:/snappy/openSUSE_Leap_42.2/ snappy
+```
+For Tumbleweed:
+
+```
+$ sudo zypper addrepo http://download.opensuse.org/repositories/system:/snappy/openSUSE_Tumbleweed/ snappy
+```
+
+After the repository is part of the system you can install snapd:
+
+```
+$ sudo zypper install snapd
+```
+
+Once the snapd package is successfully installed you have to
+enable the systemd unit which takes care about snapd's main
+communication socket as this is not yet automatically done:
+
+```
+$ sudo systemctl enable --now snapd.socket
+```
+
+Afterwards everything is setup to get you started with snaps.
+
+## Next Steps
+
+ * [Using snaps](usage.md)

--- a/core/install-opensuse.md
+++ b/core/install-opensuse.md
@@ -2,14 +2,13 @@
 title: Install snapd on openSUSE
 ---
 
-For openSUSE snapd is not yet included in the official distribution but can be
+For openSUSE, snapd is not yet included in the official distribution but can be
 installed from a community repository which is available [here](https://build.opensuse.org/package/show/system:snappy/snapd).
 
-The repository currently supports the 42.2 release and Tumbleweed. The Installation
+The repository currently supports the 42.2 release and Tumbleweed. The installation
 process for both is similar. First we need to add the repository itself.
 
 For 42.2:
-
 
 ```
 $ sudo zypper addrepo http://download.opensuse.org/repositories/system:/snappy/openSUSE_Leap_42.2/ snappy
@@ -20,7 +19,7 @@ For Tumbleweed:
 $ sudo zypper addrepo http://download.opensuse.org/repositories/system:/snappy/openSUSE_Tumbleweed/ snappy
 ```
 
-After the repository is part of the system you can install snapd:
+You can then install snapd:
 
 ```
 $ sudo zypper install snapd
@@ -38,4 +37,4 @@ Afterwards everything is setup to get you started with snaps.
 
 ## Next Steps
 
- * [Using snaps](usage.md)
+ * [Using snaps](usage)

--- a/core/install-openwrt.md
+++ b/core/install-openwrt.md
@@ -2,12 +2,12 @@
 title: Install snapd on OpenWrt
 ---
 
-The packaging of snapd for OpenWrt is available through a github repository from
+The packaging of snapd for OpenWrt is available through a GitHub repository from
 a community member [here](https://github.com/teknoraver/snap-openwrt).
 
-Detailed instructions of how snapd can be build into an OpenWrt image can be
+Detailed instructions of how snapd can be built into an OpenWrt image can be
 found as part of the repository [here](https://github.com/teknoraver/snap-openwrt/blob/master/README.md).
 
 ## Next Steps
 
- * [Using snaps](usage.md)
+ * [Using snaps](usage)

--- a/core/install-openwrt.md
+++ b/core/install-openwrt.md
@@ -1,0 +1,13 @@
+---
+title: Install snapd on OpenWrt
+---
+
+The packaging of snapd for OpenWrt is available through a github repository from
+a community member [here](https://github.com/teknoraver/snap-openwrt).
+
+Detailed instructions of how snapd can be build into an OpenWrt image can be
+found as part of the repository [here](https://github.com/teknoraver/snap-openwrt/blob/master/README.md).
+
+## Next Steps
+
+ * [Using snaps](usage.md)

--- a/core/install-ubuntu.md
+++ b/core/install-ubuntu.md
@@ -1,0 +1,19 @@
+---
+title: Install snapd on Ubuntu
+---
+
+Ubuntu includes snapd by default starting with the 16.04 (xenial) release. No
+further manual steps are required and you can use snapd directly.
+
+For the older 14.04 (trusty) release or any flavour (e.g. Lubuntu) which doesn't
+include snapd by default you have to install snapd manually from the archive:
+
+```
+$ sudo apt install snapd
+```
+
+Afterwards everything is setup to get you started with snaps.
+
+## Next Steps
+
+ * [Using snaps](usage.md)

--- a/core/install-ubuntu.md
+++ b/core/install-ubuntu.md
@@ -2,11 +2,10 @@
 title: Install snapd on Ubuntu
 ---
 
-Ubuntu includes snapd by default starting with the 16.04 (xenial) release. No
-further manual steps are required and you can use snapd directly.
+Ubuntu includes snapd by default starting with the 16.04 LTS (xenial) release. No installation steps are required and you can use snapd directly.
 
-For the older 14.04 (trusty) release or any flavour (e.g. Lubuntu) which doesn't
-include snapd by default you have to install snapd manually from the archive:
+For the older 14.04 LTS (trusty) release or any flavour (e.g. Lubuntu) which doesn't
+include snapd by default, you have to install it manually from the archive:
 
 ```
 $ sudo apt install snapd
@@ -16,4 +15,4 @@ Afterwards everything is setup to get you started with snaps.
 
 ## Next Steps
 
- * [Using snaps](usage.md)
+ * [Using snaps](usage)

--- a/core/install.md
+++ b/core/install.md
@@ -2,22 +2,22 @@
 title: Install snapd
 ---
 
-snapd is available on many different distributions. This page gives an overview
-over which are supported and what their current status is. Also it has installation
+snapd, the service you need to install to run and manage snaps, is available on many distributions. This page gives an overview
+of which ones are supported and what their current status is. It also provides installation
 instructions for each of these distributions.
 
-# Installation instructions
+## Installation instructions
 
- * [Arch Linux](install-arch-linux.md)
- * [Debian](install-debian.md)
- * [Fedora](install-fedora.md)
- * [Gentoo](install-gentoo.md)
- * [OpenEmbedded/Yocto](install-oe-yocto.md)
- * [openSUSE](install-opensuse.md)
- * [OpenWRT](install-openwrt.md)
- * [Ubuntu](install-ubuntu.md)
+ * [Arch Linux](install-arch-linux)
+ * [Debian](install-debian)
+ * [Fedora](install-fedora)
+ * [Gentoo](install-gentoo)
+ * [OpenEmbedded/Yocto](install-oe-yocto)
+ * [openSUSE](install-opensuse)
+ * [OpenWrt](install-openwrt)
+ * [Ubuntu](install-ubuntu)
 
-# Support Overview
+## Support Overview
 
 The following overview shows which version of snapd is available in each of the
 listed distributions.
@@ -33,12 +33,12 @@ listed distributions.
 | RHEL 7.3            | Unsupported | N/A     | N/A                     |
 | Arch Linux          | Outdated    | 2.16    | _devmode_               |
 | Gentoo              | Outdated    | 2.15    | _devmode_               |
-| OpenSUSE Leap 42.2  | Unsupported | 2.23.5  | N/A                     |
-| OpenSUSE Tumbleweed | Unsupported | 2.23.5  | N/A                     |
+| openSUSE Leap 42.2  | Unsupported | 2.23.5  | N/A                     |
+| openSUSE Tumbleweed | Unsupported | 2.23.5  | N/A                     |
 | Yocto               | Unsupported | 2.23.5  | _devmode_               |
 
 _devmode_: confinement technology is not fully supported and all snaps are
-installed in development mode.
+installed in [development mode](/docs/reference/confinement).
 
-_no-classic_: because of distribution policy to remove `/snap` directory, snaps
-using classic confinement are not supported.
+_no-classic_: because of distribution policy to remove the `/snap` directory, snaps
+using [classic confinement](/docs/reference/confinement) are not supported.

--- a/core/install.md
+++ b/core/install.md
@@ -2,59 +2,43 @@
 title: Install snapd
 ---
 
-### Arch
+snapd is available on many different distributions. This page gives an overview
+over which are supported and what their current status is. Also it has installation
+instructions for each of these distributions.
 
-```
-sudo pacman -S snapd
+# Installation instructions
 
-# enable the snapd systemd service:
-sudo systemctl enable --now snapd.socket
-```
+ * [Arch Linux](install-arch-linux.md)
+ * [Debian](install-debian.md)
+ * [Fedora](install-fedora.md)
+ * [Gentoo](install-gentoo.md)
+ * [OpenEmbedded/Yocto](install-oe-yocto.md)
+ * [openSUSE](install-opensuse.md)
+ * [OpenWRT](install-openwrt.md)
+ * [Ubuntu](install-ubuntu.md)
 
-### Debian
+# Support Overview
 
-```
-# On Sid:
-sudo apt install snapd
-```
+The following overview shows which version of snapd is available in each of the
+listed distributions.
 
-### Fedora
+| Operating System    | Status      | Version | Notes                   |
+| ------------------- |:-----------:| ------- | ----------------------- |
+| Ubuntu 14.04 LTS    | Supported   | 2.23    |                         |
+| Ubuntu 16.04 LTS    | Supported   | 2.23    |                         |
+| Debian (testing)    | Supported   | 2.21    | _devmode_               |
+| Debian (unstable)   | Supported   | 2.21    | _devmode_               |
+| Fedora 25           | In progress | 2.16    | _devmode_, _no-classic_ |
+| CentOS 7            | In progress | N/A     | _devmode_, _no-classic_ |
+| RHEL 7.3            | Unsupported | N/A     | N/A                     |
+| Arch Linux          | Outdated    | 2.16    | _devmode_               |
+| Gentoo              | Outdated    | 2.15    | _devmode_               |
+| OpenSUSE Leap 42.2  | Unsupported | 2.23.5  | N/A                     |
+| OpenSUSE Tumbleweed | Unsupported | 2.23.5  | N/A                     |
+| Yocto               | Unsupported | 2.21    | _devmode_               |
 
-```
-sudo dnf copr enable zyga/snapcore
-sudo dnf install snapd
+_devmode_: confinement technology is not fully supported and all snaps are
+installed in development mode.
 
-# enable the snapd systemd service:
-sudo systemctl enable --now snapd.service
-
-# SELinux support is in beta, so currently:
-sudo setenforce 0
-
-# to persist, edit /etc/selinux/config
-to set SELINUX=permissive and reboot.
-```
-
-### Gentoo
-
-Install the [gentoo-snappy overlay](https://github.com/zyga/gentoo-snappy).
-
-### OpenEmbedded/Yocto
-
-Install the [snap meta layer](https://github.com/morphis/meta-snappy/blob/master/README.md).
-
-### openSUSE
-
-```
-sudo zypper addrepo http://download.opensuse.org/repositories/system:/snappy/openSUSE_Leap_42.2/ snappy
-sudo zypper install snapd
-```
-
-### OpenWrt
-
-Enable the [snap-openwrt feed](https://github.com/teknoraver/snap-openwrt/blob/master/README.md).
-
-### Ubuntu
-
-```
-sudo apt install snapd
-```
+_no-classic_: because of distribution policy to remove `/snap` directory, snaps
+using classic confinement are not supported.

--- a/core/install.md
+++ b/core/install.md
@@ -35,7 +35,7 @@ listed distributions.
 | Gentoo              | Outdated    | 2.15    | _devmode_               |
 | OpenSUSE Leap 42.2  | Unsupported | 2.23.5  | N/A                     |
 | OpenSUSE Tumbleweed | Unsupported | 2.23.5  | N/A                     |
-| Yocto               | Unsupported | 2.21    | _devmode_               |
+| Yocto               | Unsupported | 2.23.5  | _devmode_               |
 
 _devmode_: confinement technology is not fully supported and all snaps are
 installed in development mode.

--- a/navigation.html
+++ b/navigation.html
@@ -12,12 +12,22 @@
     <li>
       <a href="/docs/core">Core</a>
       <ul>
-          <li><a href="/docs/core/install">Install</a></li>
+        <li>
+          <a href="/docs/core/install">Install</a>
+            <ul>
+              <li><a href="/docs/core/install-arch-linux">Arch</a></li>
+              <li><a href="/docs/core/install-debian">Debian</a></li>
+              <li><a href="/docs/core/install-fedora">Fedora</a></li>
+              <li><a href="/docs/core/install-gentoo">Gentoo</a></li>
+              <li><a href="/docs/core/install-oe-yocto">OpenEmbedded/Yocto</a></li>
+              <li><a href="/docs/core/install-opensuse">openSUSE</a></li>
+              <li><a href="/docs/core/install-openwrt">OpenWrt</a></li>
+              <li><a href="/docs/core/install-ubuntu">Ubuntu</a></li>
+            </ul>
+          </li>
           <li><a href="/docs/core/usage">Usage</a></li>
           <li><a href="/docs/core/store">Snap stores</a></li>
           <li><a href="/docs/core/snapd">The snapd system</a></li>
-<!--          <li><a href="/docs/core/core-classic">Core &amp; Classic</a></li>-->
-<!--          <li><a href="/docs/core/snaps">The kinds of snaps</a></li>-->
           <li><a href="/docs/core/interfaces">Interfaces (plugs and slots)</a></li>
           <li><a href="/docs/core/updates">Transactional updates</a></li>
           <li><a href="/docs/core/versions">Multiple snaps versions &amp; garbage collection</a></li>


### PR DESCRIPTION
This extends the installation instructions for all distributions we support so far to be much more verbose and also moves each into a single sub page.