### PR TITLE
Revise content related to Fedora

### DIFF
--- a/core/install-fedora.md
+++ b/core/install-fedora.md
@@ -2,51 +2,28 @@
 title: Install snapd on Fedora
 ---
 
-snapd packages for Fedora are currently not available as part of
-the official distribution but are maintained in a community
-repository in [copr](https://copr.fedorainfracloud.org/). In the
-near future snapd will be available in the official Fedora
-distribution repositories.
+snapd packages for Fedora are available from the official
+distribution repositories starting with Fedora 24.
 
-## Enable the repository
-
-There are separate repos for Fedora 24 and Fedora 25/26. Once enabled, continue to install snapd below.
-
-### Fedora 24
-
-To install snapd from the community repository you have to enable
-it first:
-
-```
-$ sudo dnf copr enable zyga/snapcore
-```
-
-### Fedora 25 / 26 & Rawhide
-
-To install snapd from the community repository you have to enable
-it first:
-
-```
-$ sudo dnf copr enable mrmorph/snapcore
-```
-
-## Install snapd
-
-Now you can install the snapd package with:
+You can install the snapd package with:
 
 ```
 $ sudo dnf install snapd
 ```
 
+After that, everything is set up to get you started with snaps.
+
+### Note for Fedora 24 users
+
 Once the snapd package is successfully installed you have to
 enable the systemd unit which takes care about snapd's main
-communication socket as this is not yet automatically done:
+communication socket as this is not automatically done:
 
 ```
 $ sudo systemctl enable --now snapd.socket
 ```
 
-Afterwards everything is setup to get you started with snaps.
+Now everything is set up to get you started with snaps.
 
 ## Next Steps
 

--- a/core/install.md
+++ b/core/install.md
@@ -28,7 +28,10 @@ listed distributions.
 | Ubuntu 16.04 LTS    | Supported   | 2.23    |                         |
 | Debian (testing)    | Supported   | 2.21    | _devmode_               |
 | Debian (unstable)   | Supported   | 2.21    | _devmode_               |
-| Fedora 25           | In progress | 2.16    | _devmode_, _no-classic_ |
+| Fedora 24           | Supported   | 2.23.6  | _devmode_, _no-classic_ |
+| Fedora 25           | Supported   | 2.23.6  | _devmode_, _no-classic_ |
+| Fedora 26           | Supported   | 2.23.6  | _devmode_, _no-classic_ |
+| Fedora Rawhide      | Supported   | 2.23.6  | _devmode_, _no-classic_ |
 | CentOS 7            | In progress | N/A     | _devmode_, _no-classic_ |
 | RHEL 7.3            | Unsupported | N/A     | N/A                     |
 | Arch Linux          | Outdated    | 2.16    | _devmode_               |


### PR DESCRIPTION
Official packages for Fedora are going to become available, so it will be much simpler for Fedorans to use Snappy.

Blocked on successful push of the following updates:

* Fedora 24: https://bodhi.fedoraproject.org/updates/FEDORA-2017-ce0fdd87a4
* Fedora 25: https://bodhi.fedoraproject.org/updates/FEDORA-2017-37a7331620
* Fedora 26: https://bodhi.fedoraproject.org/updates/FEDORA-2017-261aa8c9f4