### PR TITLE
Update sources before installing snapd on Ubuntu

### DIFF
--- a/core/install-ubuntu.md
+++ b/core/install-ubuntu.md
@@ -8,6 +8,7 @@ For the older 14.04 LTS (trusty) release or any flavour (e.g. Lubuntu) which doe
 include snapd by default, you have to install it manually from the archive:
 
 ```
+$ sudo apt update
 $ sudo apt install snapd
 ```
 


### PR DESCRIPTION
Update sources before installing snapd on Ubuntu. 16.04.1 had snapd 2.0.2, which didn't auto-update.