### PR TITLE
Always run docker pull before docker run

### DIFF
--- a/build-snaps/trusty.md
+++ b/build-snaps/trusty.md
@@ -52,6 +52,7 @@ Next, make sure Docker is running:
 
        sudo service docker status
 
-You're all set. Any time you want to build a snap, type the following command to run snapcraft relative to the current directory:
+You're all set. Any time you want to build a snap, type the following commands to run snapcraft relative to the current directory:
 
+       sudo docker pull snapcore/snapcraft
        sudo docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft


### PR DESCRIPTION
Always run docker pull before docker run, otherwise you may use an outdated snapcraft (#80).