### PR TITLE
Add Solus install instructions

### DIFF
--- a/core/install-solus.md
+++ b/core/install-solus.md
@@ -5,6 +5,12 @@ title: Install snapd on Solus
 snapd packages for Solus are available from the official
 distribution repositories.
 
+## Solus 3 (and above)
+
+Solus includes snapd by default starting with the Solus 3 release. No installation steps are required and you can use snapd directly.
+
+### For older versions
+
 Ensure your packages are up to date and install the snapd package with:
 
 ```

--- a/core/install-solus.md
+++ b/core/install-solus.md
@@ -1,0 +1,25 @@
+---
+title: Install snapd on Solus
+---
+
+snapd packages for Solus are available from the official
+distribution repositories.
+
+Ensure your packages are up to date and install the snapd package with:
+
+```
+$ sudo eopkg up
+$ sudo eopkg install snapd
+```
+
+Then reboot to ensure AppArmor and snapd are initialized:
+
+```
+$ sudo reboot
+```
+
+Now everything is set up to get you started with snaps.
+
+## Next Steps
+
+ * [Using snaps](usage)

--- a/core/install.md
+++ b/core/install.md
@@ -15,6 +15,7 @@ instructions for each of these distributions.
  * [OpenEmbedded/Yocto](install-oe-yocto)
  * [openSUSE](install-opensuse)
  * [OpenWrt](install-openwrt)
+ * [Solus](install-solus)
  * [Ubuntu](install-ubuntu)
 
 ## Support Overview

--- a/navigation.html
+++ b/navigation.html
@@ -22,6 +22,7 @@
               <li><a href="/docs/core/install-oe-yocto">OpenEmbedded/Yocto</a></li>
               <li><a href="/docs/core/install-opensuse">openSUSE</a></li>
               <li><a href="/docs/core/install-openwrt">OpenWrt</a></li>
+              <li><a href="/docs/core/install-solus">Solus</a></li>
               <li><a href="/docs/core/install-ubuntu">Ubuntu</a></li>
             </ul>
           </li>


### PR DESCRIPTION
Fixes #91

## Done

* Added Solus dedicated page and instructions
* Added Solus to the install index page
 
## Later

* Overhaul support table and drop the version col to be accurate and easier to maintain