### PR TITLE
Revise and update the Fedora snapd information

### DIFF
--- a/core/install.md
+++ b/core/install.md
@@ -30,9 +30,9 @@ listed distributions.
 | Debian (testing)    | Supported   | 2.21    | _devmode_               |
 | Debian (unstable)   | Supported   | 2.21    | _devmode_               |
 | Fedora 24           | End of Life | 2.26.3  | _devmode_, _no-classic_ |
-| Fedora 25           | Supported   | 2.24    | _devmode_, _no-classic_ |
-| Fedora 26           | Supported   | 2.24    | _devmode_, _no-classic_ |
-| Fedora Rawhide      | Supported   | 2.24    | _devmode_, _no-classic_ |
+| Fedora 25           | Supported   | 2.27.2  | _devmode_, _no-classic_ |
+| Fedora 26           | Supported   | 2.27.2  | _devmode_, _no-classic_ |
+| Fedora Rawhide      | Supported   | 2.27.2  | _devmode_, _no-classic_ |
 | CentOS 7            | In progress | N/A     | _devmode_, _no-classic_ |
 | RHEL 7.3            | Unsupported | N/A     | N/A                     |
 | Arch Linux          | Outdated    | 2.21    | _devmode_, _no-classic_ |

--- a/core/install.md
+++ b/core/install.md
@@ -32,6 +32,7 @@ listed distributions.
 | Fedora 24           | End of Life | 2.26.3  | _devmode_, _no-classic_ |
 | Fedora 25           | Supported   | 2.27.2  | _devmode_, _no-classic_ |
 | Fedora 26           | Supported   | 2.27.2  | _devmode_, _no-classic_ |
+| Fedora 27           | Supported   | 2.27.2  | _devmode_, _no-classic_ |
 | Fedora Rawhide      | Supported   | 2.27.2  | _devmode_, _no-classic_ |
 | CentOS 7            | In progress | N/A     | _devmode_, _no-classic_ |
 | RHEL 7.3            | Unsupported | N/A     | N/A                     |

--- a/core/install.md
+++ b/core/install.md
@@ -29,7 +29,7 @@ listed distributions.
 | Ubuntu 16.04 LTS    | Supported   | 2.23    |                         |
 | Debian (testing)    | Supported   | 2.21    | _devmode_               |
 | Debian (unstable)   | Supported   | 2.21    | _devmode_               |
-| Fedora 24           | Supported   | 2.24    | _devmode_, _no-classic_ |
+| Fedora 24           | End of Life | 2.26.3  | _devmode_, _no-classic_ |
 | Fedora 25           | Supported   | 2.24    | _devmode_, _no-classic_ |
 | Fedora 26           | Supported   | 2.24    | _devmode_, _no-classic_ |
 | Fedora Rawhide      | Supported   | 2.24    | _devmode_, _no-classic_ |


### PR DESCRIPTION
Note that this PR is currently blocked on the successful push of the following updates:

* Fedora 25: https://bodhi.fedoraproject.org/updates/FEDORA-2017-4f8de51e27
* Fedora 26: https://bodhi.fedoraproject.org/updates/FEDORA-2017-f24fd67e3a