### PR TITLE
Correct store name

### DIFF
--- a/build-snaps/build-for-another-arch.md
+++ b/build-snaps/build-for-another-arch.md
@@ -18,7 +18,7 @@ The basic steps are:
      * Select the Ubuntu series to build against and the target CPU architecture to build snaps for
      * Specify a PPA to use for pulling and building dependencies
      * Configure automatic building on branch changes (you can always request a build manually after setup)
-     * Configure the auto build to release on success to a specified store channel
+     * Configure the auto build to release on success to a specified Snap Store channel
 
 Depending on work loads, there may a short delay. For faster iteration, you can build on your target Ubuntu Core device.
 

--- a/build-snaps/go.md
+++ b/build-snaps/go.md
@@ -45,7 +45,7 @@ apps:
 
 #### Metadata
 
-The `snapcraft.yaml` starts with a small amount of human-readable metadata, which usually can be lifted from the GitHub description or project README.md. This data is used in the presentation of your app in the snap store. The `summary:` can not exceed 79 characters. You can use a pipe with the `description:` to declare a multi-line description.
+The `snapcraft.yaml` starts with a small amount of human-readable metadata, which usually can be lifted from the GitHub description or project README.md. This data is used in the presentation of your app in the Snap Store. The `summary:` can not exceed 79 characters. You can use a pipe with the `description:` to declare a multi-line description.
 
 ```yaml
 name: httplab
@@ -83,7 +83,7 @@ parts:
 
 Apps are the commands and services exposed to end users. If your command name matches the snap `name`, users will be able run the command directly. If the names differ, then apps are prefixed with the snap `name` (`httplab.command-name`, for example). This is to avoid conflicting with apps defined by other installed snaps.
 
-If you don’t want your command prefixed you can request an alias for it on the [Snapcraft forum](https://forum.snapcraft.io). These are set up automatically when your snap is installed from the snap store.
+If you don’t want your command prefixed you can request an alias for it on the [Snapcraft forum](https://forum.snapcraft.io). These are set up automatically when your snap is installed from the Snap Store.
 
 ```yaml
 apps:
@@ -108,7 +108,7 @@ cd httplab
 snapcraft
 ```
 
-The resulting snap can be installed locally. This requires the `--dangerous` flag because the snap is not signed by the snap store. The `--devmode` flag acknowledges that you are installing an unconfined application:
+The resulting snap can be installed locally. This requires the `--dangerous` flag because the snap is not signed by the Snap Store. The `--devmode` flag acknowledges that you are installing an unconfined application:
 
 ```
 sudo snap install httplab_*.snap --devmode --dangerous
@@ -233,7 +233,7 @@ cd go-ethereum
 snapcraft
 ```
 
-The resulting snap can be installed locally. This requires the `--dangerous` flag because the snap is not signed by the snap store. The `--devmode` flag acknowledges that you are installing an unconfined application:
+The resulting snap can be installed locally. This requires the `--dangerous` flag because the snap is not signed by the Snap Store. The `--devmode` flag acknowledges that you are installing an unconfined application:
 
 ```
 sudo snap install geth_*.snap --devmode --dangerous
@@ -253,11 +253,11 @@ sudo snap remove geth
 
 ## Share with your friends
 
-To share your snaps you need to publish them in the snap store. First, create an account on [dashboard.snapcraft.io](https://dashboard.snapcraft.io). Here you can customize how your snaps are presented, review your uploads and control publishing.
+To share your snaps you need to publish them in the Snap Store. First, create an account on [dashboard.snapcraft.io](https://dashboard.snapcraft.io). Here you can customize how your snaps are presented, review your uploads and control publishing.
 
 You’ll need to choose a unique “developer namespace” as part of the account creation process. This name will be visible by users and associated with your published snaps.
 
-Make sure the `snapcraft` command is authenticated using the email address attached to your store account:
+Make sure the `snapcraft` command is authenticated using the email address attached to your Snap Store account:
 
 ```
 snapcraft login
@@ -275,7 +275,7 @@ Be sure to update the `name:` in your `snapcraft.yaml` to match this registered 
 
 ### Upload your snap
 
-Use snapcraft to push the snap to the store.
+Use snapcraft to push the snap to the Snap Store.
 
 ```
 snapcraft push --release=edge mygosnap_*.snap

--- a/build-snaps/metadata.md
+++ b/build-snaps/metadata.md
@@ -121,11 +121,7 @@ Where `<app-name>` is the entry corresponding to `apps` in `snapcraft.yaml`.
 
 ### Package icons
 
-Providing an icon for your snap is important, even for command-line
-applications, if for nothing else than discoverability from management
-interfaces such as store fronts like snapweb.
-
-To use an icon to represent the snap, just declare a PNG or SVG in
+To use an icon to represent your snap, just declare a PNG or SVG in
 `snapcraft.yaml` through an `icon` entry with a path relative
 to the icon inside the snap.
 

--- a/build-snaps/node.md
+++ b/build-snaps/node.md
@@ -52,7 +52,7 @@ parts:
 
 #### Metadata
 
-The `snapcraft.yaml` starts with a small amount of human-readable metadata, which usually can be lifted from the GitHub description or project README.md. This data is used in the presentation of your app in the snap store. The `summary:` can not exceed 79 characters. You can use a pipe with the `description:` to declare a multi-line description.
+The `snapcraft.yaml` starts with a small amount of human-readable metadata, which usually can be lifted from the GitHub description or project README.md. This data is used in the presentation of your app in the Snap Store. The `summary:` can not exceed 79 characters. You can use a pipe with the `description:` to declare a multi-line description.
 
 ```yaml
 name: wethr
@@ -92,7 +92,7 @@ parts:
 
 Apps are the commands and services exposed to end users. If your command name matches the snap `name`, users will be able run the command directly. If the names differ, then apps are prefixed with the snap `name` (`wethr.command-name`, for example). This is to avoid conflicting with apps defined by other installed snaps.
 
-If you don’t want your command prefixed you can request an alias for it on the [Snapcraft forum](https://forum.snapcraft.io). These are set up automatically when your snap is installed from the snap store.
+If you don’t want your command prefixed you can request an alias for it on the [Snapcraft forum](https://forum.snapcraft.io). These are set up automatically when your snap is installed from the Snap Store.
 
 ```yaml
 apps:
@@ -117,7 +117,7 @@ cd wethr
 snapcraft
 ```
 
-The resulting snap can be installed locally. This requires the `--dangerous` flag because the snap is not signed by the snap store. The `--devmode` flag acknowledges that you are installing an unconfined application:
+The resulting snap can be installed locally. This requires the `--dangerous` flag because the snap is not signed by the Snap Store. The `--devmode` flag acknowledges that you are installing an unconfined application:
 
 ```
 sudo snap install wethr_*.snap --devmode --dangerous
@@ -137,11 +137,11 @@ sudo snap remove wethr
 
 ## Share with your friends
 
-To share your snaps you need to publish them in the snap store. First, create an account on [dashboard.snapcraft.io](https://dashboard.snapcraft.io). Here you can customize how your snaps are presented, review your uploads and control publishing.
+To share your snaps you need to publish them in the Snap Store. First, create an account on [dashboard.snapcraft.io](https://dashboard.snapcraft.io). Here you can customize how your snaps are presented, review your uploads and control publishing.
 
 You’ll need to choose a unique “developer namespace” as part of the account creation process. This name will be visible by users and associated with your published snaps.
 
-Make sure the `snapcraft` command is authenticated using the email address attached to your store account:
+Make sure the `snapcraft` command is authenticated using the email address attached to your Snap Store account:
 
 ```
 snapcraft login
@@ -159,7 +159,7 @@ Be sure to update the `name:` in your `snapcraft.yaml` to match this registered 
 
 ### Upload your snap
 
-Use snapcraft to push the snap to the store.
+Use snapcraft to push the snap to the Snap Store.
 
 ```
 snapcraft push --release=edge mynodesnap_*.snap

--- a/build-snaps/pre-built.md
+++ b/build-snaps/pre-built.md
@@ -47,7 +47,7 @@ apps:
 
 #### Metadata
 
-The `snapcraft.yaml` starts with a small amount of human-readable metadata, which usually can be lifted from the GitHub description or project README.md. This data is used in the presentation of your app in the snap store. The `summary:` can not exceed 79 characters. You can use a pipe with the `description:` to declare a multi-line description.
+The `snapcraft.yaml` starts with a small amount of human-readable metadata, which usually can be lifted from the GitHub description or project README.md. This data is used in the presentation of your app in the Snap Store. The `summary:` can not exceed 79 characters. You can use a pipe with the `description:` to declare a multi-line description.
 
 ```yaml
 name: geekbench4
@@ -86,7 +86,7 @@ parts:
 
 Apps are the commands and services exposed to end users. If your command name matches the snap `name`, users will be able run the command directly. If the names differ, then apps are prefixed with the snap `name` (`geekbench4.command-name`, for example). This is to avoid conflicting with apps defined by other installed snaps.
 
-If you don’t want your command prefixed you can request an alias for it on the [Snapcraft forum](https://forum.snapcraft.io). These are set up automatically when your snap is installed from the snap store.
+If you don’t want your command prefixed you can request an alias for it on the [Snapcraft forum](https://forum.snapcraft.io). These are set up automatically when your snap is installed from the Snap Store.
 
 ```yaml
 apps:
@@ -113,7 +113,7 @@ cd geekbench4
 snapcraft
 ```
 
-The resulting snap can be installed locally. This requires the `--dangerous` flag because the snap is not signed by the snap store. The `--devmode` flag acknowledges that you are installing an unconfined application:
+The resulting snap can be installed locally. This requires the `--dangerous` flag because the snap is not signed by the Snap Store. The `--devmode` flag acknowledges that you are installing an unconfined application:
 
     sudo snap install geekbench4_*.snap --devmode --dangerous
 
@@ -127,11 +127,11 @@ Removing the snap is simple too:
 
 ## Share with your friends
 
-To share your snaps you need to publish them in the snap store. First, create an account on [dashboard.snapcraft.io](https://dashboard.snapcraft.io). Here you can customize how your snaps are presented, review your uploads and control publishing.
+To share your snaps you need to publish them in the Snap Store. First, create an account on [dashboard.snapcraft.io](https://dashboard.snapcraft.io). Here you can customize how your snaps are presented, review your uploads and control publishing.
 
 You’ll need to choose a unique “developer namespace” as part of the account creation process. This name will be visible by users and associated with your published snaps.
 
-Make sure the `snapcraft` command is authenticated using the email address attached to your store account:
+Make sure the `snapcraft` command is authenticated using the email address attached to your Snap Store account:
 ```
 snapcraft login
 ```
@@ -147,7 +147,7 @@ Be sure to update the `name:` in your `snapcraft.yaml` to match this registered 
 
 ### Upload your snap
 
-Use snapcraft to push the snap to the store.
+Use snapcraft to push the snap to the Snap Store.
 
 ```
 snapcraft push --release=edge mysnap_*.snap

--- a/build-snaps/publish.md
+++ b/build-snaps/publish.md
@@ -3,14 +3,11 @@ title: "Publish your snap"
 ---
 
 
-In order to share your snaps with the world, you need to push them to a store, and release them. This page describes the process you will follow for the Ubuntu-hosted Store.
-
-Although, snaps are not tied to a specific type of store and you can host them any way you want, see the [Store](/docs/core/store) page for more details.
+You can share your snaps with the world by publishing them to the Snap Store. Alternatively, you can publish to a [brand store](/docs/core/store).
 
 ## 1. Create a store account
 
-To release snaps in the Ubuntu Store you will need to create an account
-on [dashboard.snapcraft.io](https://myapps.developer.ubuntu.com/). This is your developer portal where you can customize how your snaps are presented, review your uploads, and control the releasing process.
+To release snaps you will need to create an account on the [Snap Store dashboard](https://dashboard.snapcraft.io/). Here you can customize how your snaps are presented, review your uploads, and control the release process.
 
 You'll need to choose a unique "developer namespace" as part of the account creation process. This name will be visible by users and associated with your snaps.
 
@@ -48,7 +45,7 @@ You are now the only developer able to use this name in the store. Note that the
 
 ### Name disputes
 
-The Ubuntu Store can, if needed, rename snaps to ensure they match the expectations of most users. If you're the developer or publisher most users expect for a snap name, then claim it with the [snap name registration](https://dashboard.snapcraft.io/dev/snaps/register-name/) form. If the name is already taken, the form will let you submit a name dispute.
+If needed, snaps can be renamed to ensure they match the expectations of most users. If you're the developer or publisher most users expect for a snap name, you may claim it with the [snap name registration](https://dashboard.snapcraft.io/dev/snaps/register-name/) form.
 
 ## 3. Upload your snap
 
@@ -62,9 +59,10 @@ Before you upload your snap, have a quick look at your `snapcraft.yaml` file aga
 It's worth noting that the user of your snaps will have to use `--devmode` to install a snap using `confinement: devmode`. This means that they have to willingly accept that the snap is breaking out of confinement.
 
 ### Pushing the snap
-Snap upload to the store can be done either from the Ubuntu Store web interface or directly by using the command-line.
 
-Once you have a working snap, you can run `snapcraft push snap-name.snap` to push it to the store.
+Uploading a snap can be done either from the Snap Store dashboard or by using the command-line.
+
+Once you have a working snap, you can run `snapcraft push snap-name.snap` to push it to the Snap Store.
 
 ### Example
 
@@ -98,7 +96,7 @@ The same revision of a snap can be released into several channels at once.
 
 ### Release process
 
-Releasing can be done from the store web interface or directly from the command-line.
+Releasing can be done from the Snap Store dashboard or directly from the command-line.
 
 To release a snap, run `snapcraft release snap-name revision channel`.
 

--- a/build-snaps/publish.md
+++ b/build-snaps/publish.md
@@ -5,13 +5,13 @@ title: "Publish your snap"
 
 You can share your snaps with the world by publishing them to the Snap Store. Alternatively, you can publish to a [brand store](/docs/core/store).
 
-## 1. Create a store account
+## 1. Create a Snap Store account
 
 To release snaps you will need to create an account on the [Snap Store dashboard](https://dashboard.snapcraft.io/). Here you can customize how your snaps are presented, review your uploads, and control the release process.
 
 You'll need to choose a unique "developer namespace" as part of the account creation process. This name will be visible by users and associated with your snaps.
 
-Once you've confirmed your account, you're ready to start pushing your snaps to the Store.
+Once you've confirmed your account, you're ready to start pushing your snaps to the Snap Store.
 
 Make sure the `snapcraft` and `snap` commands know about you by logging in using the email address attached to your account.
 
@@ -29,7 +29,7 @@ You can push your own version of a snap, provided you do so under a name you hav
 
 New names can be registered:
 
-* by clicking **New Snap** at the top of the Store
+* by clicking **New Snap** at the top of the Snap Store dashboard
 * by visiting: [the name registration page](https://dashboard.snapcraft.io/dev/snaps/register-name/)
 * or by running `snapcraft register snap-name`
 
@@ -41,7 +41,7 @@ New names can be registered:
     Registering drone-autopilot.
     Congratulations! You're now the publisher for 'drone-autopilot'.
 
-You are now the only developer able to use this name in the store. Note that the store allows you to share snaps management (push and release) with other developers on a per-snap basis.
+You are now the only developer able to use this name in the Snap Store. Note that the Snap Store allows you to share snaps management (push and release) with other developers on a per-snap basis.
 
 ### Name disputes
 
@@ -77,7 +77,7 @@ Note that `snapcraft push` will return an error if you try to push a snap with a
 
 ### Revisions
 
-Each time you upload a snap, the store will assigned a revision number to it, starting at 1. This revision number will be incremented each time you upload a new version of your snap. The revision number also increments when uploading a build for a new architecture. 
+Each time you upload a snap, the Snap Store will assign a revision number to it, starting at 1. This revision number will be incremented each time you upload a new version of your snap. The revision number also increments when uploading a build for a new architecture. 
 
 ## 4. Release your snap
 

--- a/build-snaps/python.md
+++ b/build-snaps/python.md
@@ -47,7 +47,7 @@ parts:
  
 #### Metadata
  
-The `snapcraft.yaml` starts with a small amount of human-readable metadata, which usually can be lifted from the GitHub description or project README.md. This data is used in the presentation of your app in the snap store. The `summary:` can not exceed 79 characters. You can use a pipe with the `description:` to declare a multi-line description.
+The `snapcraft.yaml` starts with a small amount of human-readable metadata, which usually can be lifted from the GitHub description or project README.md. This data is used in the presentation of your app in the Snap Store. The `summary:` can not exceed 79 characters. You can use a pipe with the `description:` to declare a multi-line description.
  
 ```yaml
 name: offlineimap
@@ -85,7 +85,7 @@ parts:
  
 Apps are the commands and services exposed to end users. If your command name matches the snap `name`, users will be able run the command directly. If the names differ, then apps are prefixed with the snap `name` (`offlineimap.command-name`, for example). This is to avoid conflicting with apps defined by other installed snaps.
  
-If you don’t want your command prefixed you can request an alias for it on the [Snapcraft forum](https://forum.snapcraft.io). These command aliases are set up automatically when your snap is installed from the snap store.
+If you don’t want your command prefixed you can request an alias for it on the [Snapcraft forum](https://forum.snapcraft.io). These command aliases are set up automatically when your snap is installed from the Snap Store.
  
 ```yaml
 apps:
@@ -110,7 +110,7 @@ cd offlineimap
 snapcraft
 ```
  
-The resulting snap can be installed locally. This requires the `--dangerous` flag because the snap is not signed by the snap store. The `--devmode` flag acknowledges that you are installing an unconfined application:
+The resulting snap can be installed locally. This requires the `--dangerous` flag because the snap is not signed by the Snap Store. The `--devmode` flag acknowledges that you are installing an unconfined application:
  
     sudo snap install offlineimap_*.snap --devmode --dangerous
  
@@ -176,7 +176,7 @@ cd youtube-dl
 snapcraft
 ```
  
-The resulting snap can be installed locally. This requires the `--dangerous` flag because the snap is not signed by the snap store. The `--devmode` flag acknowledges that you are installing an unconfined application:
+The resulting snap can be installed locally. This requires the `--dangerous` flag because the snap is not signed by the Snap Store. The `--devmode` flag acknowledges that you are installing an unconfined application:
  
     sudo snap install youtube-dl_*.snap --devmode --dangerous
  
@@ -190,11 +190,11 @@ Removing the snap is simple too:
  
 ## Share with your friends
  
-To share your snaps you need to publish them in the snap store. First, create an account on [dashboard.snapcraft.io](https://dashboard.snapcraft.io). Here you can customize how your snaps are presented, review your uploads and control publishing.
+To share your snaps you need to publish them in the Snap Store. First, create an account on [dashboard.snapcraft.io](https://dashboard.snapcraft.io). Here you can customize how your snaps are presented, review your uploads and control publishing.
  
 You’ll need to choose a unique “developer namespace” as part of the account creation process. This name will be visible by users and associated with your published snaps.
  
-Make sure the `snapcraft` command is authenticated using the email address attached to your store account:
+Make sure the `snapcraft` command is authenticated using the email address attached to your Snap Store account:
 ```
 snapcraft login
 ```
@@ -211,7 +211,7 @@ Be sure to update the `name:` in your `snapcraft.yaml` to match this registered 
  
 ### Upload your snap
  
-Use snapcraft to push the snap to the store.
+Use snapcraft to push the snap to the Snap Store.
  
 ```
 snapcraft push --release=edge mypthonsnap_*.snap

--- a/build-snaps/syntax.md
+++ b/build-snaps/syntax.md
@@ -13,7 +13,7 @@ contain. They are separated by categories to make this document clearer, but can
 
 ### General metadata
 
-The following keys are used to declare the general metadata of your snap: how it will be presented to users, its version, development status and how the store should consider it (ready for a release in the `stable` channel or not).
+The following keys are used to declare the general metadata of your snap: how it will be presented to users, its version, development status and how the Snap Store should consider it (ready for a release in the `stable` channel or not).
 
 * `name` (string)
   The name of the resulting snap.

--- a/build-snaps/your-first-snap.md
+++ b/build-snaps/your-first-snap.md
@@ -19,8 +19,8 @@ summary: Single-line elevator pitch for your amazing snap # 79 char long summary
 description: |
   This is my-snap's description. You have a paragraph or two to tell the
   most important story about your snap. Keep it under 100 words though,
-  we live in tweetspace and your description wants to look good in the snap
-  store.
+  we live in tweetspace and your description wants to look good in the Snap
+  Store.
 
 grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: devmode # use 'strict' once you have the right plugs and slots

--- a/core/snapd.md
+++ b/core/snapd.md
@@ -30,7 +30,7 @@ On a snapd system these features are implemented by:
 
 ![Snaps are self contained, confined applications that can make use of features in other snaps using Interfaces.](../media/snap_in_snappy_system.png "Snaps in the Snapd System")
 
-The snapd system simplifies the development of devices and their software because, with the exception of a limited number of OS features, you're in control of all the components in your application. You simply add everything needed to the snap package. You then make the snap available using [the store](/docs/core/store "the store"), or, if you are the device creator, create your own store.
+The snapd system simplifies the development of devices and their software because, with the exception of a limited number of OS features, you're in control of all the components in your application. You simply add everything needed to the snap package. You then make the snap available using the [Snap Store](/docs/core/store "Snap Store"), or, if you are the device creator, create your own store.
 
 ## OS snaps
 

--- a/core/store.md
+++ b/core/store.md
@@ -10,7 +10,7 @@ The main way of distributing snaps to snapd systems is through the [Snap Store](
 
 ### Developer namespace
 
-You'll choose a unique developer namespace as part of the store account creation process. This namespace will represent you as a publisher in the store and you won't be able to change it afterwards.
+You'll choose a unique developer namespace as part of the account creation process. This namespace will represent you as a publisher in the Snap Store and you won't be able to change it afterwards.
 
 ### Naming
 
@@ -18,9 +18,9 @@ You can release a snap under any name you have rights to. Names can be registere
 
 ### Pushing
 
-Pushing snaps to the store can be done directly with the [`snapcraft push`](/docs/build-snaps/publish "snapcraft push") command or on the [Snap Store dashboard](https://dashboard.snapcraft.io "Snap Store dashboard") itself. Once pushed, you choose the release channel(s) (`stable`, `candidate`, `beta`, `edge`) that the snap will be released into.
+Pushing to the Snap Store can be done directly with the [`snapcraft push`](/docs/build-snaps/publish "snapcraft push") command or on the [Snap Store dashboard](https://dashboard.snapcraft.io "Snap Store dashboard") itself. Once pushed, you choose the release channel(s) (`stable`, `candidate`, `beta`, `edge`) that the snap will be released into.
 
-It's worth noting that when you push a snap, the store assigns it a revision number of 1\. The store then automatically increments this revision number each time you push a new version.
+It's worth noting that when you push a snap, the Snap Store assigns it a revision number of 1\. The Snap Store then automatically increments this revision number each time you push a new version.
 
 ### Releasing
 
@@ -30,7 +30,7 @@ Once your snap has been reviewed and approved, you can release it when you're re
 
 ### Release channels
 
-On the store, snaps can be published into different channels at the same time: `stable`, `candidate` (release candidate), `beta`, and `edge`. This enables you to engage with users who are willing to test changes, and helps users decide how close to the leading edge of development they want to be.
+On the Snap Store, snaps can be published into different channels at the same time: `stable`, `candidate` (release candidate), `beta`, and `edge`. This enables you to engage with users who are willing to test changes, and helps users decide how close to the leading edge of development they want to be.
 
 By default, snaps are installed from the `stable` channel. Versions of snaps from other channels need to be explicitly selected:
 

--- a/core/store.md
+++ b/core/store.md
@@ -4,9 +4,9 @@ title: Snap stores
 
 There are multiple ways to distribute snaps as the format is not tied to a specific distribution system.
 
-## The Ubuntu Store
+## The Snap Store
 
-The main way of distributing snaps to snapd systems is through [the Ubuntu Store](https://dashboard.snapcraft.io "Ubuntu store"), where you can customize how your snap is presented, review each new pushed snap, and control their release process over several release channels. Here is the model it follows.
+The main way of distributing snaps to snapd systems is through the [Snap Store](https://dashboard.snapcraft.io "Snap Store"), where you can customize how your snap is presented, review each new pushed snap, and control their release process over several release channels. Here is the model it follows.
 
 ### Developer namespace
 
@@ -18,7 +18,7 @@ You can release a snap under any name you have rights to. Names can be registere
 
 ### Pushing
 
-Pushing snaps to the store can be done directly with the [`snapcraft push`](/docs/build-snaps/publish "snapcraft push") command or on the [store website](https://dashboard.snapcraft.io "Ubuntu store") itself. Once pushed, you choose the release channel(s) (`stable`, `candidate`, `beta`, `edge`) that the snap will be released into.
+Pushing snaps to the store can be done directly with the [`snapcraft push`](/docs/build-snaps/publish "snapcraft push") command or on the [Snap Store dashboard](https://dashboard.snapcraft.io "Snap Store dashboard") itself. Once pushed, you choose the release channel(s) (`stable`, `candidate`, `beta`, `edge`) that the snap will be released into.
 
 It's worth noting that when you push a snap, the store assigns it a revision number of 1\. The store then automatically increments this revision number each time you push a new version.
 
@@ -53,4 +53,4 @@ Snaps are not tied to a specific type of store and you can host them any way you
 
 You can find an example implementation of a custom store [here](https://github.com/noise/snapstore/). You can even deploy it locally by running `$ snap install snapstore-example`. See the README of the project for details.
 
-Brands can also take advantage of a [Brand store](https://docs.ubuntu.com/core/en/build-store/index), a white label store offering similar to the Ubuntu Store.
+Brands can also take advantage of a [Brand store](https://docs.ubuntu.com/core/en/build-store/index), a white label store offering similar to the Snap Store.

--- a/core/updates.md
+++ b/core/updates.md
@@ -9,7 +9,7 @@ Snapd systems employ a method of transactional updates that is available for all
 Each snap -- be it a kernel, OS, gadget, or application snap -- is delivered as a read only, squashfs file. When installed it's stored in a directory named with its revision number (`/var/lib/snapd/snaps/<snap>_<rev>.snap`) and accompanied by revision numbered writable spaces (which are all symlinked to `current`, for example `snap/<name>/current`). In addition, the snap also gets a common multi-revision writable space.
 
 ## Update (Refresh)
-When the snap is updated (by the user running `$ snap refresh <snap name>`) a new set of directories are created labeled with the snap's revision number (which is incremented each time a snap is added to the store). The read-only image of the new version is stored in the new directory, new writable spaces are created, and the data from the previous version's writable spaces copied to the new ones. Data in the common space isn't altered in any way. The new version's snap and writable areas then are both symlinked to `current`. The process is illustrated below:
+When the snap is updated (by the user running `$ snap refresh <snap name>`) a new set of directories are created labeled with the snap's revision number (which is incremented each time a snap is added to the Snap Store). The read-only image of the new version is stored in the new directory, new writable spaces are created, and the data from the previous version's writable spaces copied to the new ones. Data in the common space isn't altered in any way. The new version's snap and writable areas then are both symlinked to `current`. The process is illustrated below:
 
 ![The lifecycle of a snap's update](../media/transactional_update.png)
 

--- a/core/usage.md
+++ b/core/usage.md
@@ -4,11 +4,11 @@ title: "Use the snap command"
 
 This is an overview of commonly used snap commands. You can find the full command reference [here](/docs/reference/snap-command).
 
-## Log in to a snap store
+## Log in to the Snap Store
 
-Snaps are normally installed from a [store](/docs/core/store). You can interact with a store without signing-in, but signing-in offers a number of advantages. These advantages include the ability to access your private snaps and managing your snaps without requiring root on the device.
+Snaps are normally installed from the Snap Store. You can interact with the Snap Store without signing-in, but signing-in offers a number of advantages. These advantages include the ability to access your private snaps and managing your snaps without requiring root on the device.
 
-Snap stores hold a collection of snaps for delivery to clouds, devices, and private infrastructures. You sign-in to a store as follows, using your [Ubuntu One account](https://login.ubuntu.com/+login):
+The Snap Store holds a collection of snaps for delivery to clouds, devices, and private infrastructures. You sign-in as follows, using your [Ubuntu One account](https://login.ubuntu.com/+login):
 
     $ sudo snap login me@myself.com
     Password: *********
@@ -19,9 +19,9 @@ When you are not logged in, most `snap` commands will require you to run them as
 
 ## Find snaps
 
-A store can contain both public and private snaps.
+The Snap Store contains both public and private snaps.
 
-Anybody can publish a snap, but doing a store search will only find snaps that are published to the `stable` release channel (and therefore have been reviewed and judged to be of good quality -- so users can install them without concerns).
+Anybody can publish a snap, but doing a Snap Store search will only find snaps that are published to the `stable` release channel (and therefore have been reviewed and judged to be of good quality -- so users can install them without concerns).
 
 Searches look for matches in the snap name or description:
 
@@ -31,7 +31,7 @@ Searches look for matches in the snap name or description:
     hello-huge     1.0      noise      -      A really big snap
     hello-world    6.1      canonical  -      Hello world example
 
-Community developer Brian Douglass is also maintaining an [online frontend](https://uappexplorer.com/apps?type=snappy&sort=-last_updated) to browse the main snap store.
+Community developer Brian Douglass is also maintaining an [online frontend](https://uappexplorer.com/apps?type=snappy&sort=-last_updated) to browse the Snap Store.
 
 ## Install snaps
 

--- a/core/usage.md
+++ b/core/usage.md
@@ -8,7 +8,7 @@ This is an overview of commonly used snap commands. You can find the full comman
 
 Snaps are normally installed from a [store](/docs/core/store). You can interact with a store without signing-in, but signing-in offers a number of advantages. These advantages include the ability to access your private snaps and managing your snaps without requiring root on the device.
 
-Snap stores hold a collection of snaps for delivery to clouds, devices, and private infrastructures. You sign-in to a store as follows, using your [Ubuntu SSO account](https://login.ubuntu.com/+login):
+Snap stores hold a collection of snaps for delivery to clouds, devices, and private infrastructures. You sign-in to a store as follows, using your [Ubuntu One account](https://login.ubuntu.com/+login):
 
     $ sudo snap login me@myself.com
     Password: *********

--- a/deprecation-notices/dn5.md
+++ b/deprecation-notices/dn5.md
@@ -2,7 +2,7 @@
 title: DN2
 ---
 
-**Aliases are now handled by the store, and shouldn't be placed in the snap.**
+**Aliases are now handled by the Snap Store, and shouldn't be placed in the snap.**
 
 _introduced in snapcraft 2.35_
 
@@ -11,15 +11,15 @@ coding it into the snap. A few problems manifested with this approach:
 
 1. Users could not add aliases that were not explicitly added by the snap
    author.
-2. Aliases could be selected piecemeal by the store and by users, which was
+2. Aliases could be selected piecemeal by the Snap Store and by users, which was
    flexible but too heavy for the common case of just getting software to work.
 
 To solve these issues, aliases are no longer carried within the snap itself
-with the `aliases` property, but handled completely by the store. Users are
+with the `aliases` property, but handled completely by the Snap Store. Users are
 free to setup aliases under their control (via `snap alias`), and automatic
 aliases are also handled as a block, being enabled or disabled together.
 
-To get aliases in the store, the developer needs to request them and get
+To get aliases in the Snap Store, the developer needs to request them and get
 approval from the developer community. This process happens in the Snapcraft
 forum; see the [request guidelines][1].
 

--- a/reference/channels.md
+++ b/reference/channels.md
@@ -28,7 +28,7 @@ See the [command-line usage](#command-line-usage) section for practical examples
 
 ### Discoverability of snaps
 
-The snap search API (used by the `snap find` command, the snapweb store UI snap and others) only returns results for snaps in channels with **a "stable" risk level and no branch**. This ensures stability for users.
+The snap search API (used by the `snap find` command) only returns results for snaps in channels with **a "stable" risk level and no branch**. This ensures stability for users.
 
 Nevertheless, if you know the name of a snap, the `snap info <snap>` command will give you its complete tracks and risk levels map.
 

--- a/reference/confinement.md
+++ b/reference/confinement.md
@@ -22,11 +22,11 @@ See the list of [environment variables](/docs/reference/env) for more details on
 
 ### devmode
 
-Developer mode, also known as `devmode`, uses the same security policies as `strict` confinement, but security denials are turned into warnings in `/var/log/syslog` (see [Debugging](/docs/build-snaps/debugging)). This is useful when snapping an application, to discover which [interfaces](/docs/core/interfaces) need to be declared. Snaps in developer mode can **not** be released into the stable and candidate store [channels](/docs/reference/channels).
+Developer mode, also known as `devmode`, uses the same security policies as `strict` confinement, but security denials are turned into warnings in `/var/log/syslog` (see [Debugging](/docs/build-snaps/debugging)). This is useful when snapping an application, to discover which [interfaces](/docs/core/interfaces) need to be declared. Snaps in developer mode can **not** be released into the stable and candidate Snap Store [channels](/docs/reference/channels).
 
 ### classic
 
-A snap in `classic` confinement behaves as a traditionally packaged application, with full access to the system. As opposed to `strict` and `devmode`, what a `classic` snap sees as "`/`" is the host system's "`/`" and not the `core` snap's "`/`". Snaps using this fully open security policy are manually reviewed in the store and are only allowed on systems where `snapd` is installed [on top of a traditional Linux distribution](/docs/core/install), as opposed to system booting from an [Ubuntu Core image](https://docs.ubuntu.com/core/en/guides/build-device/image-building). They can be released in all store [channels](/docs/reference/channels).
+A snap in `classic` confinement behaves as a traditionally packaged application, with full access to the system. As opposed to `strict` and `devmode`, what a `classic` snap sees as "`/`" is the host system's "`/`" and not the `core` snap's "`/`". Snaps using this fully open security policy are manually reviewed in the Snap Store and are only allowed on systems where `snapd` is installed [on top of a traditional Linux distribution](/docs/core/install), as opposed to system booting from an [Ubuntu Core image](https://docs.ubuntu.com/core/en/guides/build-device/image-building). They can be released in all Snap Store [channels](/docs/reference/channels).
 
 ## Declaring confinement
 

--- a/reference/env.md
+++ b/reference/env.md
@@ -31,9 +31,9 @@ Typical value `6.3`
 
 ### `SNAP_REVISION`
 
-Revision of the snap, as allocated by the store on upload or as allocated by snapd for locally installed snaps.
+Revision of the snap, as allocated by the Snap Store on upload or as allocated by snapd for locally installed snaps.
 
-The store assigns monotonic revisions to each upload of a given snap. Snapd uses store revisions if accompanying assertions are available or uses a locally generated number. Locally generated numbers are prefixed with `x` to distinguish them from store uploads.
+The Snap Store assigns monotonic revisions to each upload of a given snap. Snapd uses Snap Store revisions if accompanying assertions are available or uses a locally generated number. Locally generated numbers are prefixed with `x` to distinguish them from Snap Store uploads.
 
 Typical value: `27` or `x1`
 

--- a/reference/snap-command.md
+++ b/reference/snap-command.md
@@ -8,8 +8,8 @@ title: "snap: command reference"
 ## Store commands
 
 * [`find`:](#find)       Finds packages to install
-* [`login:`](#login)       Authenticates on snapd and the store
-* [`logout:`](#logout)      Log out of the store
+* [`login:`](#login)       Authenticates on snapd and the Snap Store
+* [`logout:`](#logout)      Log out of the Snap Store
 * [`buy:`](#buy)         Buys a snap
 
 ## Manage snaps on a system
@@ -52,7 +52,7 @@ title: "snap: command reference"
 
 Usage: `snap find <query>`
 
-The find command queries the store for available packages.
+The find command queries the Snap Store for available packages.
 
 #### Command options
  * `--private`:  Search private snaps
@@ -62,7 +62,7 @@ The find command queries the store for available packages.
 
 Usage: `snap login <email>`
 
-The login command authenticates on snapd and the snap store and saves credentials
+The login command authenticates on snapd and the Snap Store and saves credentials
 into the `~/.snap/auth.json` file. Further communication with snapd will then be made using those credentials.
 
 Login only works for local users in the `sudo`, `admin` or `wheel` groups.
@@ -73,13 +73,13 @@ An account can be setup at [https://login.ubuntu.com](https://login.ubuntu.com)
 
 Usage: `snap logout`
 
-This command logs the current user out of the store
+This command logs the current user out of the Snap Store
 
 ### buy
 
 Usage: `snap buy <snap>`
 
-The buy command buys a snap from the store.
+The buy command buys a snap from the Snap Store.
 
 #### Command options
 

--- a/reference/snapcraft-command.md
+++ b/reference/snapcraft-command.md
@@ -49,17 +49,17 @@ List the available plugins that handle different types of part.
 
 #### login
 
-Authenticate session against Ubuntu One SSO.
+Authenticate session against Ubuntu One.
 
   Usage:
 
     $ snapcraft login
-    Enter your Ubuntu One SSO credentials.
+    Enter your Ubuntu One credentials.
     Email: foo@bar.com
     Password:
     One-time password (just press enter if you don't use two-factor authentication):
     123456
-    Authenticating against Ubuntu One SSO.
+    Authenticating against Ubuntu One.
     Login successful.
 
 
@@ -71,14 +71,14 @@ Clear session credentials.
   Usage:
 
     $ snapcraft logout
-    Clearing credentials for Ubuntu One SSO.
+    Clearing credentials for Ubuntu One.
     Credentials cleared.
 
 
 
 #### register
 
-Register a package name in the store.
+Register a package name in the Snap Store.
 
   Usage:
 

--- a/reference/snapcraft-command.md
+++ b/reference/snapcraft-command.md
@@ -102,7 +102,7 @@ Setup the snapcraft examples tour in the specified directory, or `./snapcraft-to
 
 #### upload
 
-Upload a snap to the Ubuntu Store.
+Upload a snap to the Snap Store.
 
   Usage:
 


### PR DESCRIPTION
I've spoken with Gustavo and Jamie and confirmed that the store should be called Snap Store, not "Ubuntu Store." This matches reality: users of any Linux-based operating system can install snaps, not just those running Ubuntu.