### PR TITLE
Update Fedora snapd to 2.27.6

### DIFF
--- a/core/install.md
+++ b/core/install.md
@@ -30,10 +30,10 @@ listed distributions.
 | Debian (testing)    | Supported   | 2.21    | _devmode_               |
 | Debian (unstable)   | Supported   | 2.21    | _devmode_               |
 | Fedora 24           | End of Life | 2.26.3  | _devmode_, _no-classic_ |
-| Fedora 25           | Supported   | 2.27.2  | _devmode_, _no-classic_ |
-| Fedora 26           | Supported   | 2.27.2  | _devmode_, _no-classic_ |
-| Fedora 27           | Supported   | 2.27.2  | _devmode_, _no-classic_ |
-| Fedora Rawhide      | Supported   | 2.27.2  | _devmode_, _no-classic_ |
+| Fedora 25           | Supported   | 2.27.6  | _devmode_, _no-classic_ |
+| Fedora 26           | Supported   | 2.27.6  | _devmode_, _no-classic_ |
+| Fedora 27           | Supported   | 2.27.6  | _devmode_, _no-classic_ |
+| Fedora Rawhide      | Supported   | 2.27.6  | _devmode_, _no-classic_ |
 | CentOS 7            | In progress | N/A     | _devmode_, _no-classic_ |
 | RHEL 7.3            | Unsupported | N/A     | N/A                     |
 | Arch Linux          | Outdated    | 2.21    | _devmode_, _no-classic_ |


### PR DESCRIPTION
This is pending the push of the following Bodhi updates:

* Fedora 27: https://bodhi.fedoraproject.org/updates/FEDORA-2017-4546b9dd38
* Fedora 26: https://bodhi.fedoraproject.org/updates/FEDORA-2017-8ef8c9e6c2
* Fedora 25: https://bodhi.fedoraproject.org/updates/FEDORA-2017-d699df2619