### PR TITLE
Put the language guides in a grid with logos

### DIFF
--- a/build-snaps/languages.md
+++ b/build-snaps/languages.md
@@ -2,9 +2,21 @@
 title: "Language guides"
 ---
 
-Create snaps from your preferred programming language:
+Create snaps from your preferred programming language.
 
-* [Pre-built apps](/docs/build-snaps/pre-built)
-* [Node](/docs/build-snaps/node)
-* [Go](/docs/build-snaps/go)
-* [Python](/docs/build-snaps/python)
+<div class="eight-col">
+  <ul class="inline-logos equal-height">
+    <li class="inline-logos__item box">
+      <a href="/docs/build-snaps/pre-built"><img class="inline-logos__image" src="{{ site.asset_path }}7af63a6d-workflow-icon04.svg" alt="Pre-built apps" /><br />Pre-built apps</a>
+    </li>
+    <li class="inline-logos__item box">
+      <a href="/docs/build-snaps/go"><img class="inline-logos__image" src="{{ site.asset_path }}c85a212e-go-logo.png" alt="Go" /><br />Go</a>
+    </li>
+    <li class="inline-logos__item box">
+      <a href="/docs/build-snaps/node"><img class="inline-logos__image" src="{{ site.asset_path }}9735ad74-node-logo.png" alt="Node" /><br />Node.js</a>
+    </li>
+    <li class="inline-logos__item box">
+      <a href="/docs/build-snaps/python"><img class="inline-logos__image" src="{{ site.asset_path }}c3d9d13f-python-logo.png" alt="Python" /><br />Python</a>
+    </li>
+  </ul>
+</div>

--- a/build-snaps/languages.md
+++ b/build-snaps/languages.md
@@ -7,7 +7,7 @@ Create snaps from your preferred programming language.
 <div class="eight-col">
   <ul class="inline-logos equal-height">
     <li class="inline-logos__item box">
-      <a href="/docs/build-snaps/pre-built"><img class="inline-logos__image" src="{{ site.asset_path }}7af63a6d-workflow-icon04.svg" alt="Pre-built apps" /><br />Pre-built apps</a>
+      <a href="/docs/build-snaps/pre-built"><img class="inline-logos__image" src="{{ site.asset_path }}f14812c7-adwaita-package.png" alt="Pre-built apps" /><br />Pre-built apps</a>
     </li>
     <li class="inline-logos__item box">
       <a href="/docs/build-snaps/go"><img class="inline-logos__image" src="{{ site.asset_path }}c85a212e-go-logo.png" alt="Go" /><br />Go</a>

--- a/build-snaps/languages.md
+++ b/build-snaps/languages.md
@@ -7,7 +7,7 @@ Create snaps from your preferred programming language.
 <div class="eight-col">
   <ul class="inline-logos equal-height">
     <li class="inline-logos__item box">
-      <a href="/docs/build-snaps/pre-built"><img class="inline-logos__image" src="{{ site.asset_path }}f14812c7-adwaita-package.png" alt="Pre-built apps" /><br />Pre-built apps</a>
+      <a href="/docs/build-snaps/pre-built"><img class="inline-logos__image" src="{{ site.asset_path }}24be2e8c-adwaita-package.png" alt="Pre-built apps" /><br />Pre-built apps</a>
     </li>
     <li class="inline-logos__item box">
       <a href="/docs/build-snaps/go"><img class="inline-logos__image" src="{{ site.asset_path }}c85a212e-go-logo.png" alt="Go" /><br />Go</a>


### PR DESCRIPTION

![screen shot 2017-09-20 at 15 02 52](https://user-images.githubusercontent.com/1523179/30648002-ddfb5792-9e14-11e7-8183-8ff1b3a413db.png)

Requires https://github.com/canonical-websites/snapcraft.io/pull/381