### PR TITLE
Clicking logo should go to snapcraft.io

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -42,7 +42,7 @@
                     <a href="#main-content">Jump to main content</a>
                 </span>
                 <div class="logo">
-                    <a href="/">
+                    <a href="https://snapcraft.io/">
                         <img src="https://assets.ubuntu.com/v1/d45097a4-snapcraft.io-logotype.svg" alt="Snapcraft.io">
                     </a>
                 </div>


### PR DESCRIPTION
It's not ideal (normally you'd expect clicking the logo to take you to the top page of your current domain) but as there's currently no other link to https://snapcraft.io, this seems like the quickest fix to providing one.

The way to get to the top page of documentation is to click the "docs" navigation item. This is not ideal, but people will probably find it eventually.

QA
--

``` bash
./run
```

Go to <http://127.0.0.1:8004>, browse around, click the logo.