### PR TITLE
reference/common: rename snap keyword to prime

### DIFF
--- a/reference/plugins/common.md
+++ b/reference/plugins/common.md
@@ -100,7 +100,7 @@ of the choice of plugin.
           - -usr/lib/libtest.so   # Excludng libtest.so
           - $manpages                 # Including the 'manpages' fileset
 
-  - `snap`: YAML file and fileset list
+  - `prime`: YAML file and fileset list
 
     A list of files from a part install directory to copy into `prime/`.
     This section takes exactly the same form as the 'stage' section  but the


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io-static-pages/issues/389