### PR TITLE
Make COMMIT_ID a required arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM ubuntu:xenial
 RUN apt-get update && apt-get install --yes nginx
 
 # Set git commit ID
-ARG COMMIT_ID=""
+ARG COMMIT_ID
+RUN test -n "${COMMIT_ID}"
 
 # Copy over files
 WORKDIR /srv


### PR DESCRIPTION
Apologies for going back and forth on this.

Basically, I had this clever idea that if I made the COMMIT_ID optional, then I could setup [automated builds on hub.docker.com](https://docs.docker.com/docker-hub/builds/) so that the `canonicalwebteam/docs.snapcraft.io` image would automatically build every time this repo changes. Obviously the automated build wouldn't be able to provide a COMMIT_ID, so making it optional would make this possible.

But then I tried it out and discovered that of course I actually need to be running `./run build` before `docker build` - which again is impossible for automated builds. So building of `canonicalwebteam/docs.snapcraft.io` will need a more intellegent build system anyway. So we might as well be more declarative and make COMMIT_ID mandatory, so we know we can always expect to find it in our built images.

QA
--

``` bash
./run clean  # Remove things
docker build .  # Fails asking for COMMIT_ID
docker build --build-arg COMMIT_ID=`git rev-parse HEAD` .  # Fails, _site directory doesn't exist
./run build
docker build --build-arg COMMIT_ID=`git rev-parse HEAD` .  # Succeeds! Hooray!
```