### PR TITLE
Surface moos guide in the nav and languages page

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -40,6 +40,16 @@
       <a href="/build-snaps">Build snaps</a>
       <ul>
           <li><a href="/build-snaps/your-first-snap">Your first snap</a></li>
+          <li>
+            <a href="/build-snaps/languages">Languages</a>
+            <ul>
+                <li><a href="/build-snaps/pre-built">Pre-built apps</a></li>
+                <li><a href="/build-snaps/node">Node</a></li>
+                <li><a href="/build-snaps/go">Go</a></li>
+                <li><a href="/build-snaps/python">Python</a></li>
+                <li><a href="/build-snaps/moos">MOOS</a></li>
+            </ul>
+          </li>
           <li><a href="/build-snaps/syntax">Snapcraft syntax</a></li>
           <li><a href="/build-snaps/parts">Parts</a></li>
           <li><a href="/build-snaps/plugins">Plugins</a></li>

--- a/build-snaps/languages.md
+++ b/build-snaps/languages.md
@@ -19,5 +19,8 @@ Create snaps from your preferred programming language.
     <li class="inline-logos__item box">
       <a href="/build-snaps/python"><img class="inline-logos__image" src="{{ site.asset_path }}c3d9d13f-python-logo.png" alt="Python" /><br />Python</a>
     </li>
+    <li class="inline-logos__item box">
+      <a href="/build-snaps/moos"><img class="inline-logos__image" src="{{ site.asset_path }}04ff3e39-MOOSV-10-256.jpg" alt="MOOS" /><br />MOOS</a>
+    </li>
   </ul>
 </div>

--- a/build-snaps/node.md
+++ b/build-snaps/node.md
@@ -5,7 +5,7 @@ title: Node
 
 <iframe height="450" src="https://www.youtube.com/embed/S3YvRALc2C0?rel=0&showinfo=0" allowfullscreen></iframe>
 
-Node has rich tools for packaging, distributing and sandboxing applications. Snapcraft builds on top of these familiar tools such as `npm` and `yarn` to create snaps. 
+Node has rich tools for packaging, distributing and sandboxing applications. Snapcraft builds on top of these familiar tools such as `npm` and `yarn` to create snaps.
 
 ## What problems do snaps solve for Node applications?
 
@@ -93,7 +93,7 @@ parts:
 
 Apps are the commands and services exposed to end users. If your command name matches the snap `name`, users will be able run the command directly. If the names differ, then apps are prefixed with the snap `name` (`wethr.command-name`, for example). This is to avoid conflicting with apps defined by other installed snaps.
 
-If you don’t want your command prefixed you can request an alias for it on the [Snapcraft forum](https://forum.snapcraft.io). These are set up automatically when your snap is installed from the Snap Store.
+If you don’t want your command prefixed you can request an alias for it on the [Snapcraft forum](https://forum.snapcraft.io/t/process-for-reviewing-aliases-auto-connections-and-track-requests/455). These are set up automatically when your snap is installed from the Snap Store.
 
 ```yaml
 apps:


### PR DESCRIPTION
Splitted out from #133 
* surface moos guide in the nav
* move languages up 
* refine forum link in moos.md


![screenshot from 2017-10-05 12-33-50](https://user-images.githubusercontent.com/18480003/31223142-9f4c03e6-a9c9-11e7-93f4-7315222039b8.png)